### PR TITLE
CoreDataをCloudKitで扱う

### DIFF
--- a/InventoryApp-okubo/InventoryApp-okubo.xcodeproj/project.pbxproj
+++ b/InventoryApp-okubo/InventoryApp-okubo.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		7F0798FC27D9B630006BF1CF /* ImagePickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F0798FB27D9B630006BF1CF /* ImagePickerView.swift */; };
 		7F0798FE27D9BF21006BF1CF /* ImageLibraryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F0798FD27D9BF21006BF1CF /* ImageLibraryView.swift */; };
 		7F1DC17F28328D1300992908 /* SearchResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F1DC17E28328D1300992908 /* SearchResult.swift */; };
+		7F2F05062924D24200AEEF97 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F2F05052924D24200AEEF97 /* AppDelegate.swift */; };
 		7F317B6727E1C84300E1C2E1 /* Color.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F317B6627E1C84300E1C2E1 /* Color.swift */; };
 		7F46DCF12849D44800AB2715 /* RegisterRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F46DCF02849D44800AB2715 /* RegisterRowView.swift */; };
 		7F47C30127D742D9006343B4 /* RegisterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F47C30027D742D9006343B4 /* RegisterView.swift */; };
@@ -30,6 +31,7 @@
 		7F730DD528092600002EBD76 /* ItemImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F730DD428092600002EBD76 /* ItemImageView.swift */; };
 		7F7660F6283A2D9E009D6291 /* CameraManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F7660F5283A2D9E009D6291 /* CameraManager.swift */; };
 		7F7CD3E727D8EA8A005A953B /* ItemListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F7CD3E627D8EA8A005A953B /* ItemListView.swift */; };
+		7F84416A28FE3ADB001E06CE /* NoFolderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F84416928FE3ADB001E06CE /* NoFolderView.swift */; };
 		7F944CA72877ED72008894AE /* FolderEditView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F944CA62877ED72008894AE /* FolderEditView.swift */; };
 		7F944CA92877EE44008894AE /* FolderRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F944CA82877EE44008894AE /* FolderRowView.swift */; };
 		7F944CAB2877EEF9008894AE /* Urgency.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F944CAA2877EEF9008894AE /* Urgency.swift */; };
@@ -52,6 +54,8 @@
 		7F0798FB27D9B630006BF1CF /* ImagePickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagePickerView.swift; sourceTree = "<group>"; };
 		7F0798FD27D9BF21006BF1CF /* ImageLibraryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageLibraryView.swift; sourceTree = "<group>"; };
 		7F1DC17E28328D1300992908 /* SearchResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResult.swift; sourceTree = "<group>"; };
+		7F27C36728E57C0F0025F181 /* InventoryApp-okubo.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "InventoryApp-okubo.entitlements"; sourceTree = "<group>"; };
+		7F2F05052924D24200AEEF97 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		7F317B6627E1C84300E1C2E1 /* Color.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Color.swift; sourceTree = "<group>"; };
 		7F46DCF02849D44800AB2715 /* RegisterRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterRowView.swift; sourceTree = "<group>"; };
 		7F47C30027D742D9006343B4 /* RegisterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterView.swift; sourceTree = "<group>"; };
@@ -72,6 +76,7 @@
 		7F730DD428092600002EBD76 /* ItemImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemImageView.swift; sourceTree = "<group>"; };
 		7F7660F5283A2D9E009D6291 /* CameraManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraManager.swift; sourceTree = "<group>"; };
 		7F7CD3E627D8EA8A005A953B /* ItemListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemListView.swift; sourceTree = "<group>"; };
+		7F84416928FE3ADB001E06CE /* NoFolderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoFolderView.swift; sourceTree = "<group>"; };
 		7F944CA62877ED72008894AE /* FolderEditView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FolderEditView.swift; sourceTree = "<group>"; };
 		7F944CA82877EE44008894AE /* FolderRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FolderRowView.swift; sourceTree = "<group>"; };
 		7F944CAA2877EEF9008894AE /* Urgency.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Urgency.swift; sourceTree = "<group>"; };
@@ -104,6 +109,7 @@
 			children = (
 				7F47C30027D742D9006343B4 /* RegisterView.swift */,
 				7F46DCF02849D44800AB2715 /* RegisterRowView.swift */,
+				7F84416928FE3ADB001E06CE /* NoFolderView.swift */,
 			);
 			path = RegisterGroup;
 			sourceTree = "<group>";
@@ -185,7 +191,9 @@
 		7F70E1CC27D1E55900C483B9 /* InventoryApp-okubo */ = {
 			isa = PBXGroup;
 			children = (
+				7F27C36728E57C0F0025F181 /* InventoryApp-okubo.entitlements */,
 				7F70E1CD27D1E55900C483B9 /* InventoryApp_okuboApp.swift */,
+				7F2F05052924D24200AEEF97 /* AppDelegate.swift */,
 				7F70E1CF27D1E55900C483B9 /* ContentView.swift */,
 				7F18DA8528111A30005472AC /* RegisterGroup */,
 				7F18DA8628111B6A005472AC /* FolderGroup */,
@@ -321,12 +329,14 @@
 				7F0798FA27D9B268006BF1CF /* BarcodeReaderView.swift in Sources */,
 				7F944CA92877EE44008894AE /* FolderRowView.swift in Sources */,
 				7FF951A8288150F700F7F7C1 /* Item+CoreDataProperties.swift in Sources */,
+				7F84416A28FE3ADB001E06CE /* NoFolderView.swift in Sources */,
 				7FE8968327E4463B002E80B1 /* ListRowView.swift in Sources */,
 				7F7660F6283A2D9E009D6291 /* CameraManager.swift in Sources */,
 				7F067E0928A93D03000FA713 /* NotificationManager.swift in Sources */,
 				7F5A6B9327E2EC6900DCCE81 /* Icon.swift in Sources */,
 				7FF951A6288150F700F7F7C1 /* Folder+CoreDataProperties.swift in Sources */,
 				7F46DCF12849D44800AB2715 /* RegisterRowView.swift in Sources */,
+				7F2F05062924D24200AEEF97 /* AppDelegate.swift in Sources */,
 				7F5BA4D327D64CE800338C12 /* SettingView.swift in Sources */,
 				7F4EFA5727EA187C0005461E /* ItemDataView.swift in Sources */,
 				7F70E1D027D1E55900C483B9 /* ContentView.swift in Sources */,
@@ -477,6 +487,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = "InventoryApp-okubo/InventoryApp-okubo.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
@@ -496,7 +507,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.icloud.slow-dancer-815.InventoryApp-okubo";
+				PRODUCT_BUNDLE_IDENTIFIER = "slow-dancer-815.InventoryApp-okubo";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -510,6 +521,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = "InventoryApp-okubo/InventoryApp-okubo.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
@@ -529,7 +541,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.icloud.slow-dancer-815.InventoryApp-okubo";
+				PRODUCT_BUNDLE_IDENTIFIER = "slow-dancer-815.InventoryApp-okubo";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/InventoryApp-okubo/InventoryApp-okubo.xcodeproj/xcshareddata/xcschemes/InventoryApp-okubo.xcscheme
+++ b/InventoryApp-okubo/InventoryApp-okubo.xcodeproj/xcshareddata/xcschemes/InventoryApp-okubo.xcscheme
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1400"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "7F70E1C927D1E55900C483B9"
+               BuildableName = "InventoryApp-okubo.app"
+               BlueprintName = "InventoryApp-okubo"
+               ReferencedContainer = "container:InventoryApp-okubo.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "7F70E1C927D1E55900C483B9"
+            BuildableName = "InventoryApp-okubo.app"
+            BlueprintName = "InventoryApp-okubo"
+            ReferencedContainer = "container:InventoryApp-okubo.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "-com.apple.CoreData.SQLDebug"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "-com.apple.CoreData.MigrationDebug"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "-com.apple.CoreData.Logging.stderr 0"
+            isEnabled = "YES">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "-com.apple.CoreData.CloudKitDebug"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "-com.apple.CoreData.ConcurrencyDebug"
+            isEnabled = "NO">
+         </CommandLineArgument>
+      </CommandLineArguments>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "7F70E1C927D1E55900C483B9"
+            BuildableName = "InventoryApp-okubo.app"
+            BlueprintName = "InventoryApp-okubo"
+            ReferencedContainer = "container:InventoryApp-okubo.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/InventoryApp-okubo/InventoryApp-okubo/AppDelegate.swift
+++ b/InventoryApp-okubo/InventoryApp-okubo/AppDelegate.swift
@@ -1,0 +1,80 @@
+//
+//  AppDelegate.swift
+//  InventoryApp-okubo
+//
+//  Created by 大久保徹郎 on 2022/11/16.
+//
+
+import UIKit
+import CloudKit
+
+class AppDelegate: NSObject, UIApplicationDelegate {
+    // 起動時
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
+        print("アプリ起動")
+        // ローカル通知の許可
+        NotificationManager().requestPermission()
+        // データベース
+        let containerIdentifier = "iCloud.InventoryApp-okubo"
+        let ckContainer = CKContainer(identifier: containerIdentifier)
+        let cloudDatabase = ckContainer.privateCloudDatabase
+        // cloud変更のサブスクリプション作成
+        let subscriptionID = "com.apple.coredata.cloudkit.private.subscription"
+        let ckSubscription = CKQuerySubscription(recordType: "CD_Item",
+                                               predicate: NSPredicate(value: true),
+                                               subscriptionID: subscriptionID,
+                                               options: [.firesOnRecordCreation,
+                                                         .firesOnRecordUpdate,
+                                                         .firesOnRecordDeletion])
+        let recordZoneName = "com.apple.coredata.cloudkit.zone"
+        let recordZone = CKRecordZone(zoneName: recordZoneName)
+        ckSubscription.zoneID = recordZone.zoneID
+        // 通知設定
+        let notification = CKSubscription.NotificationInfo()
+        notification.shouldSendContentAvailable = true
+        // 通知されるデータを設定
+        notification.desiredKeys = ["CD_name", "CD_id", "CD_notificationDate"]
+        ckSubscription.notificationInfo = notification
+        // TODO: - 一度iCloudの同期を切って戻してもサブスクリプションがエラーになり続けて機能しなくなる不具合
+        // データベースにサブスクリプションを登録
+        cloudDatabase.save(ckSubscription) { subscription, error in
+            if let error = error {
+                print("サブスクリプション失敗： \(error.localizedDescription)")
+            } else {
+                print("サブスクリプション開始： \(String(describing: subscription))")
+            }
+        }
+        return true
+    }
+    // リモート通知を受け取った時の処理
+    func application(_ application: UIApplication, didReceiveRemoteNotification userInfo: [AnyHashable : Any], fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void) {
+        // このユーザーインフォからデータが取れるか調査
+        if let dictionary = userInfo as? [String: NSObject],
+           let notification = CKNotification(fromRemoteNotificationDictionary: dictionary),
+           let querynotification = notification as? CKQueryNotification {
+            // querynotification.queryNotificationReasonが作成・更新・削除を表す
+            let reason = querynotification.queryNotificationReason
+            print("変更：\(reason)")
+            print("リモート通知：\(String(describing: querynotification.recordFields))")
+            // 取得したデータ
+            guard let recordFields = querynotification.recordFields else { return }
+            // 商品名
+            let name = recordFields["CD_name"] as? String
+            print("商品名：\(String(describing: name))")
+            // 識別ID
+            let id = recordFields["CD_id"] as? String
+            print("id: \(String(describing: id))")
+            // 通知日程
+            if let notificationDate = recordFields["CD_notificationDate"] as? NSNumber {
+                print("通知：\(String(describing: notificationDate)), \(String(describing: type(of: notificationDate)))")
+                let date = Date(timeIntervalSinceReferenceDate: notificationDate.doubleValue)
+                print("日付：\(String(describing: date))")// TimeZoneを指定する必要あり
+            }
+            // TODO: - クラウドからの変更を受け取ったとき、通知も更新したい
+            completionHandler(.newData)
+        } else {
+            print("データなし")
+            completionHandler(.noData)
+        }
+    }
+}

--- a/InventoryApp-okubo/InventoryApp-okubo/ContentView.swift
+++ b/InventoryApp-okubo/InventoryApp-okubo/ContentView.swift
@@ -6,16 +6,8 @@
 //
 
 import SwiftUI
-import CoreData
 
 struct ContentView: View {
-    // MARK: - プロパティ
-    // 被管理オブジェクトコンテキスト（ManagedObjectContext）の取得
-    @Environment(\.managedObjectContext) private var context
-    // フォルダデータの取得
-    @FetchRequest(entity: Folder.entity(),
-                  sortDescriptors: [NSSortDescriptor(keyPath: \Folder.id, ascending: true)])
-    private var folders: FetchedResults<Folder>
     // MARK: - View
     var body: some View {
         TabView {
@@ -35,10 +27,6 @@ struct ContentView: View {
                     Text("設定")
                 }
         }
-        .onAppear {
-            makeFirstFolder()
-            NotificationManager().requestPermission()
-        }
     }// body
     // MARK: - メソッド
     init() {
@@ -53,43 +41,6 @@ struct ContentView: View {
         segmentedAppearance.setTitleTextAttributes([.foregroundColor: UIColor.orange], for: .normal)
         // 選択時の色
         segmentedAppearance.setTitleTextAttributes([.foregroundColor: UIColor.white], for: .selected)
-    }
-    // フォルダの初期値を設定する関数（アプリ初回起動を想定）
-    func makeFirstFolder() {
-        // フォルダが一つも無い時
-        if folders.count == 0 {
-            print("初期データ作成")
-            // 食品フォルダ作成
-            let foodFolder = Folder(context: context)
-            foodFolder.id = UUID()
-            foodFolder.name = "食品"
-            foodFolder.icon = Icon.food.rawValue
-            foodFolder.isStock = true
-            // 日用品フォルダ作成
-            let dailyFolder = Folder(context: context)
-            dailyFolder.id = UUID()
-            dailyFolder.name = "日用品"
-            dailyFolder.icon = Icon.house.rawValue
-            dailyFolder.isStock = true
-            // 買い物フォルダ作成
-            let buyFolder = Folder(context: context)
-            buyFolder.id = UUID()
-            buyFolder.name = "買い物リスト"
-            buyFolder.icon = Icon.cart.rawValue
-            buyFolder.isStock = false
-            do {
-                // 保存
-                try context.save()
-                print("初期フォルダ設定完了")
-            } catch {
-                print(error)
-            }
-        } else {
-            print("データあり")
-            for folder in folders {
-                print(folder.name!)
-            }
-        }
     }
 }
 

--- a/InventoryApp-okubo/InventoryApp-okubo/CoreData/Model.xcdatamodeld/Model.xcdatamodel/contents
+++ b/InventoryApp-okubo/InventoryApp-okubo/CoreData/Model.xcdatamodeld/Model.xcdatamodel/contents
@@ -1,26 +1,22 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="20086" systemVersion="21G83" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="21279" systemVersion="21G115" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithCloudKit="YES" userDefinedModelVersionIdentifier="">
     <entity name="Folder" representedClassName="Folder" syncable="YES">
-        <attribute name="icon" attributeType="String"/>
-        <attribute name="id" attributeType="UUID" usesScalarValueType="NO"/>
-        <attribute name="isStock" attributeType="Boolean" usesScalarValueType="YES"/>
-        <attribute name="name" attributeType="String"/>
-        <relationship name="items" toMany="YES" deletionRule="Nullify" destinationEntity="Item" inverseName="folder" inverseEntity="Item"/>
+        <attribute name="icon" optional="YES" attributeType="String"/>
+        <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="isStock" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="name" optional="YES" attributeType="String"/>
+        <relationship name="items" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Item" inverseName="folder" inverseEntity="Item"/>
     </entity>
     <entity name="Item" representedClassName="Item" syncable="YES">
         <attribute name="deadLine" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
-        <attribute name="id" attributeType="UUID" usesScalarValueType="NO"/>
-        <attribute name="image" optional="YES" attributeType="Binary"/>
-        <attribute name="isHurry" attributeType="Boolean" usesScalarValueType="YES"/>
-        <attribute name="name" attributeType="String"/>
+        <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="image" optional="YES" attributeType="Binary" storedInTruthFile="YES"/>
+        <attribute name="isHurry" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="name" optional="YES" attributeType="String"/>
         <attribute name="notificationDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="numberOfItems" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
-        <attribute name="registrationDate" attributeType="Date" usesScalarValueType="NO"/>
-        <attribute name="status" attributeType="String"/>
+        <attribute name="registrationDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="status" optional="YES" attributeType="String"/>
         <relationship name="folder" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Folder" inverseName="items" inverseEntity="Folder"/>
     </entity>
-    <elements>
-        <element name="Folder" positionX="-63" positionY="-18" width="128" height="104"/>
-        <element name="Item" positionX="-54" positionY="-9" width="128" height="179"/>
-    </elements>
 </model>

--- a/InventoryApp-okubo/InventoryApp-okubo/CoreData/Persistence.swift
+++ b/InventoryApp-okubo/InventoryApp-okubo/CoreData/Persistence.swift
@@ -6,8 +6,9 @@
 //
 
 import CoreData
+import CloudKit
 
-struct PersistenceController {
+class PersistenceController {
     static let shared = PersistenceController()
     // プレビューで扱うデータ
     static var preview: PersistenceController = {
@@ -40,18 +41,87 @@ struct PersistenceController {
         return result
     }()
     // 永続化コンテナ
-    let container: NSPersistentContainer
+    let container: NSPersistentCloudKitContainer
     // 初期化
     init(inMemory: Bool = false) {
-        container = NSPersistentContainer(name: "Model")
+        container = NSPersistentCloudKitContainer(name: "Model")
         if inMemory {
             container.persistentStoreDescriptions.first!.url = URL(fileURLWithPath: "/dev/null")
         }
-        container.loadPersistentStores(completionHandler: { (storeDescription, error) in
-            print(storeDescription)
+        guard let description = container.persistentStoreDescriptions.first else {
+            fatalError("Persistent Store Description の取得に失敗")
+        }
+        // Persistent Historyのトラッキング有効
+        description.setOption(true as NSNumber, forKey: NSPersistentHistoryTrackingKey)
+        // リモートの変更を検知
+        description.setOption(true as NSNumber, forKey: NSPersistentStoreRemoteChangeNotificationPostOptionKey)
+        container.loadPersistentStores(completionHandler: { (_, error) in
             if let error = error as NSError? {
                 fatalError("Unresolved error \(error), \(error.userInfo)")
             }
         })
+        // TODO: - iCloudの同期を切っても、それまで登録していたデータはローカルに残したい
+//        description.cloudKitContainerOptions = nil
+        // データが重複しないよう外部変更はメモリ内を置き換える
+        container.viewContext.mergePolicy = NSMergePolicy(merge: .mergeByPropertyObjectTrumpMergePolicyType)
+        // クラウドからの変更を自動取得して適用する
+        container.viewContext.automaticallyMergesChangesFromParent = true
+        do {
+            // Contextを現在のPersistentStoreにpinする
+            try container.viewContext.setQueryGenerationFrom(.current)
+        } catch {
+            print("viewContextを現世代に固定することに失敗しました。")
+        }
     }
+    // MARK: - CKQuerySubscriptionがうまくいきそうなので不要に
+    // リモートからの新規トランザクションを監視し、必要に応じて Context の更新などを行う
+    //        NotificationCenter.default.addObserver(self,
+    //                                               selector: #selector(storeRemoteChange(_:)),
+    //                                               name: .NSPersistentStoreRemoteChange,
+    //                                               object: container.persistentStoreCoordinator)
+    // リモートの変更を受け取った時の処理
+//    @objc func storeRemoteChange(_ notification: Notification) {
+//        precondition(notification.name == NSNotification.Name.NSPersistentStoreRemoteChange)
+//        //        print("変更通知：　\(String(describing: notification.userInfo))")
+//        //        let storeURL = notification.userInfo?[NSPersistentStoreURLKey]!
+//        let token = notification.userInfo?[NSPersistentHistoryTokenKey] as? NSPersistentHistoryToken
+//        print("リモート変更通知: \(String(describing: token))")
+//        // データ履歴取得
+//        let historyRequest = NSPersistentHistoryChangeRequest.fetchHistory(after: token)
+//        let result = try? container.newBackgroundContext().execute(historyRequest) as? NSPersistentHistoryResult
+//        //        print("変更履歴：　\(String(describing: result))")
+//        if let transactions = result?.result as? [NSPersistentHistoryTransaction] {
+//            for transaction in transactions {
+//                print("トランザクション：\(String(describing: transaction))")
+//                guard let userInfo = transaction.objectIDNotification().userInfo else { return }
+//                print("ユーザーインフォ：\(userInfo)")
+//                // データ履歴のキー
+//                let insertedKey = "inserted_objectIDs" // 追加
+//                let updatedKey = "updated_objectIDs" // 更新
+//                let deletedKey = "deleted_objectIDs" // 削除
+//                // NSManagedObjectIDの集合に変換
+//                if let updatedID = userInfo[deletedKey] as? Set<NSManagedObjectID> {
+//                    print("ID: \(updatedID)")
+//                    print(type(of: updatedID))
+//                    // NSManagedObjectIDの配列に変換
+//                    let idArray = Array(updatedID)
+//                    // NSPersistentCloudKitContainerからCKRecordsを取得
+//                    let record = container.record(for: idArray[0])
+//                    print("レコード： \(String(describing: record))")
+//                    // CKRecordから値を取りたいキー
+//                    let entityKey = "CD_entityName" // エンティティ名
+//                    let nameKey = "CD_name" // 商品名
+//                    let uuidKey = "CD_id" // UUID
+//                    let notificationKey = "CD_notificationDate" // 通知日程
+//                    let folderKey = "CD_folder" // フォルダ
+//                    if let entity = record?[entityKey] as? String {
+//                        if entity == "Item" {
+//                            let name = record?[nameKey] as? String
+//                            print("レコード： \(String(describing: name))")
+//                        }
+//                    }
+//                }
+//            }
+//        }
+//    }
 }

--- a/InventoryApp-okubo/InventoryApp-okubo/FolderGroup/View/FolderView.swift
+++ b/InventoryApp-okubo/InventoryApp-okubo/FolderGroup/View/FolderView.swift
@@ -30,31 +30,37 @@ struct FolderView: View {
     // MARK: - View
     var body: some View {
         NavigationView {
-            Form {
-                // 在庫リストのフォルダ
-                Section {
-                    ForEach(stockFolders) { folder in
-                        FolderRowView(isEditing: $isEditing, showSheet: $showSheet,
-                                      folderID: $folderID, folder: folder)
-                    }// ForEach
-                } header: {
-                    Text("在庫リスト")
+            VStack {
+                Form {
+                    // 在庫リストのフォルダ
+                    Section {
+                        ForEach(stockFolders) { folder in
+                            FolderRowView(isEditing: $isEditing, showSheet: $showSheet,
+                                          folderID: $folderID, folder: folder)
+                        }// ForEach
+                    } header: {
+                        Text("在庫リスト")
+                    }
+                    // 買い物リストのフォルダ
+                    Section {
+                        ForEach(buyFolders) { folder in
+                            FolderRowView(isEditing: $isEditing, showSheet: $showSheet,
+                                          folderID: $folderID, folder: folder)
+                        }// ForEach
+                    } header: {
+                        Text("買い物リスト")
+                    }
+                }// Form
+                // フォルダが無い場合の表示
+                if stockFolders.isEmpty && buyFolders.isEmpty {
+                    NoFolderView()
                 }
-                // 買い物リストのフォルダ
-                Section {
-                    ForEach(buyFolders) { folder in
-                        FolderRowView(isEditing: $isEditing, showSheet: $showSheet,
-                                      folderID: $folderID, folder: folder)
-                    }// ForEach
-                } header: {
-                    Text("買い物リスト")
-                }
-            }// Form
+            }
             .sheet(isPresented: $showSheet, content: {
                 // 設定画面
                 FolderEditView(folderID: $folderID)
             })
-            .navigationTitle("フォルダ")
+            .navigationTitle(titleText())
             .toolbar {
                 // 編集ボタン
                 ToolbarItem(placement: .navigationBarTrailing, content: {
@@ -69,6 +75,7 @@ struct FolderView: View {
                             Text("編集")
                         }
                     })
+                    .disabled(stockFolders.isEmpty && buyFolders.isEmpty)
                 })
                 // 新規作成ボタン
                 ToolbarItem(placement: .bottomBar, content: {
@@ -85,6 +92,15 @@ struct FolderView: View {
                 })
             }// toolbar
         }// NavigationView
+    }
+    // MARK: - メソッド
+    // navigationTitleの文字列を返す関数
+    private func titleText() -> String {
+        if isEditing {
+            return "編集中"
+        } else {
+            return "フォルダ"
+        }
     }
 }
 

--- a/InventoryApp-okubo/InventoryApp-okubo/Info.plist
+++ b/InventoryApp-okubo/InventoryApp-okubo/Info.plist
@@ -6,5 +6,9 @@
 	<array>
 		<string>ja</string>
 	</array>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>remote-notification</string>
+	</array>
 </dict>
 </plist>

--- a/InventoryApp-okubo/InventoryApp-okubo/InventoryApp-okubo.entitlements
+++ b/InventoryApp-okubo/InventoryApp-okubo/InventoryApp-okubo.entitlements
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>aps-environment</key>
+	<string>development</string>
+	<key>com.apple.developer.icloud-container-identifiers</key>
+	<array>
+		<string>iCloud.InventoryApp-okubo</string>
+	</array>
+	<key>com.apple.developer.icloud-services</key>
+	<array>
+		<string>CloudKit</string>
+	</array>
+</dict>
+</plist>

--- a/InventoryApp-okubo/InventoryApp-okubo/InventoryApp_okuboApp.swift
+++ b/InventoryApp-okubo/InventoryApp-okubo/InventoryApp_okuboApp.swift
@@ -9,6 +9,8 @@ import SwiftUI
 
 @main
 struct InventoryApp_okuboApp: App {
+    // AppDelegate設定
+    @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
     // NSPersistentContainerの初期化
     let persistenceController = PersistenceController.shared
     var body: some Scene {

--- a/InventoryApp-okubo/InventoryApp-okubo/RegisterGroup/NoFolderView.swift
+++ b/InventoryApp-okubo/InventoryApp-okubo/RegisterGroup/NoFolderView.swift
@@ -1,0 +1,121 @@
+//
+//  NoFolderView.swift
+//  InventoryApp-okubo
+//
+//  Created by 大久保徹郎 on 2022/10/18.
+//
+
+import SwiftUI
+import CoreData
+// iCloud・CoreDataに登録されたデータがない場合のView
+struct NoFolderView: View {
+    // MARK: - プロパティ
+    // 被管理オブジェクトコンテキスト（ManagedObjectContext）の取得
+    @Environment(\.managedObjectContext) private var context
+    // フォルダデータの取得
+    @FetchRequest(entity: Folder.entity(),
+                  sortDescriptors: [NSSortDescriptor(keyPath: \Folder.id, ascending: true)],
+                  animation: .default)
+    private var folders: FetchedResults<Folder>
+    // iCloudのデータをロード中の判定
+    @State private var importing = false
+    // iCloudの同期状態を通知するパブリッシャー
+    @State private var publisher = NotificationCenter.default.publisher(for: NSPersistentCloudKitContainer.eventChangedNotification)
+    // MARK: - View
+    var body: some View {
+        VStack {
+            Spacer()
+            // 同期中の表示
+            if importing {
+                Text("iCloudに同期中…")
+                    .font(.title)
+                    .foregroundColor(.gray)
+                    .multilineTextAlignment(.center)
+                    .padding(.bottom)
+                ProgressView()
+            } else {
+                Text("フォルダがありません。")
+                    .font(.title)
+                    .foregroundColor(.gray)
+                    .multilineTextAlignment(.center)
+                    .padding(.bottom)
+                Text("新規データを登録するにはフォルダが必要です。")
+                    .foregroundColor(.gray)
+                    .multilineTextAlignment(.center)
+                Text("iCloudのデータに同期している場合はしばらくお待ちください。")
+                    .foregroundColor(.gray)
+                    .multilineTextAlignment(.center)
+                    .padding(.bottom)
+                Button("初期フォルダ作成") {
+                    makeFirstFolder()
+                }
+                .font(.title3)
+                .foregroundColor(.white)
+                .padding(.all)
+                .background(Color.orange)
+                .cornerRadius(10)
+            }
+            Spacer()
+        }
+        .frame(minWidth: 0, maxWidth: .infinity,
+               minHeight: 0, maxHeight: .infinity, alignment: .center)
+        // 同期ステータスが変更された時の処理
+        .onReceive(publisher) { notification in
+            if let userInfo = notification.userInfo {
+                if let event = userInfo["event"] as? NSPersistentCloudKitContainer.Event {
+                    if event.type == .import {
+                        // データのインポート中
+                        importing = true
+                    } else {
+                        // 同期なし or データのインポート終了
+                        importing = false
+                    }
+                }
+            }
+        }
+    }
+    // MARK: - メソッド
+    // フォルダの初期値を設定する関数（アプリ初回起動を想定）
+    func makeFirstFolder() {
+        // フォルダが一つも無い時
+        if folders.count == 0 {
+            print("初期データ作成")
+            // 日用品フォルダ作成
+            let dailyFolder = Folder(context: context)
+            dailyFolder.id = UUID()
+            dailyFolder.name = "日用品"
+            dailyFolder.icon = Icon.house.rawValue
+            dailyFolder.isStock = true
+            // 食品フォルダ作成
+            let foodFolder = Folder(context: context)
+            foodFolder.id = UUID()
+            foodFolder.name = "食品"
+            foodFolder.icon = Icon.food.rawValue
+            foodFolder.isStock = true
+            // 買い物フォルダ作成
+            let buyFolder = Folder(context: context)
+            buyFolder.id = UUID()
+            buyFolder.name = "買い物リスト"
+            buyFolder.icon = Icon.cart.rawValue
+            buyFolder.isStock = false
+            do {
+                // 保存
+                try context.save()
+                print("初期フォルダ設定完了")
+            } catch {
+                print(error)
+            }
+        } else {
+            print("データあり")
+            for folder in folders {
+                print(folder.name!)
+            }
+        }
+    }
+}
+
+struct NoFolderView_Previews: PreviewProvider {
+    static var previews: some View {
+        NoFolderView()
+    }
+}

--- a/InventoryApp-okubo/InventoryApp-okubo/SettingView.swift
+++ b/InventoryApp-okubo/InventoryApp-okubo/SettingView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import CloudKit
 // 設定画面　TabViewで扱うView
 struct SettingView: View {
     // MARK: - View
@@ -32,6 +33,28 @@ struct SettingView: View {
             }// Form
             .navigationTitle("設定")
         }// NavigationView
+    }
+    // iCloudアカウントの状態をチェックする関数
+    func accountRequest() {
+        CKContainer.default().accountStatus { status, error in
+            if let error = error {
+                print("iCloudアカウントの状態確認に失敗: \(error.localizedDescription)")
+            }
+            switch status {
+            case .available:
+                print("iCloudアカウントが利用可能")
+            case .couldNotDetermine:
+                print("状態を判断できなかった")
+            case .restricted:
+                print("iCloudアカウントへのアクセスを拒否")
+            case .noAccount:
+                print("iCloudアカウントにログインされていない")
+            case .temporarilyUnavailable:
+                print("iCloudアカウントは一時的に利用できません")
+            @unknown default:
+                print("iCloudアカウントの不明なエラー")
+            }
+        }
     }
 }
 


### PR DESCRIPTION
<!-- Issueのテンプレートです。入力できるところを埋めてください。 -->
<!-- 記入しない項目は特になしと記入してください。。 -->

<!-- 関連Isuueを記載してください。close #の後にIssue番号を記載すると連携でき、プルリクのマージ時にIssueもcloseします。 -->
## 関連Isuue番号
close #30

<!-- 追加、または修正する機能の概要を記述してください。 -->
## 追加・変更の概要
CoreDataとCloudKitを連携させる。
初期データの作成を手動で行うよう変更する。
クラウドの商品データの変更を購読する。
<!-- なぜこの追加・変更が必要なのか目的を記述してください。 -->
## 変更の目的
iCloudを使用してデバイス間のデータ連携を実装するため。
<!-- 進捗状況をチェックボックスで管理してください。 -->
## タスクの進捗状況
- [x] ProjectにiCloudを追加する。
- [x] CloudKit Dashboardにデータの定義をする。
- [x] Persistence.swiftファイルにCloudkit用のコードを追加する。
- [x] フォルダが存在しない場合のViewとiCloudに同期中のViewを作成する。
- [x] データの更新があった時、通知の更新に必要な情報を取得する。

<!-- UIのキャプチャ、APIのリクエスト/レスポンス等、変更内容を明確に記述してください。 -->
## 変更内容
・NSPersistentContainerをNSPersistentCloudKitContainerに変更し、マージポリシーなどを設定
・AppDelegateファイルを追加し、CloudKitのサブスクリプションとそれに伴う通知を設定
・フォルダが存在しない場合のViewを作成。ファイル名: NoFolderView
・初期データはNoFolderViewのボタンで行うよう変更。（クラウドにデータがある場合に初期フォルダは必要ないため）

![IMG_0498](https://user-images.githubusercontent.com/53589421/202621660-af2f0b40-5ca5-4e02-9c2d-625dd3b38137.PNG)
![IMG_0499](https://user-images.githubusercontent.com/53589421/202622136-f43ca2d0-bf9f-4fb6-9621-4e6c9398b208.PNG)


・NoFolderViewに、iCloudに同期している時の表示を追加。
![IMG_0501](https://user-images.githubusercontent.com/53589421/202621993-7eea6999-2726-429a-9240-69c79377875a.PNG)


<!-- 影響範囲を予め明確に想定して記述してください。 -->
## 影響範囲
AppDelegate, PersistenceController, NoFolderView
<!-- 追加・変更した機能の操作方法を記述してください。キャプチャや動画を添付してください。 -->
## 操作方法

<!-- テストしたことをリストアップしてください。 -->
## テストしたこと
シミュレーターでデータを更新した時、実機で変更通知を受け取る。
一度iCloudの同期を切って、再接続した時に同期中のインジケーターが出るかチェック。
<!-- 相談事項や、重点的にレビューしてほしいところを記述してください。 -->
## 相談事項
iCloudの同期を切るとサブスクリプションがエラーが起きます。
このエラーを解消するためにはダッシュボードいじる必要があるので、iCloudの同期は切らないでください。
おそらくサブスクリプションを保存する方法に問題がありそうなので、次のissueで取り組みます。