### PR TITLE
サブスクリプションの変更通知からローカル通知を作成する

### DIFF
--- a/InventoryApp-okubo/InventoryApp-okubo/AppDelegate.swift
+++ b/InventoryApp-okubo/InventoryApp-okubo/AppDelegate.swift
@@ -9,68 +9,105 @@ import UIKit
 import CloudKit
 
 class AppDelegate: NSObject, UIApplicationDelegate {
+    // MARK: - プロパティ
+    // サブスクリプション作成済みかを表すBool（UserDefaultsで保存）
+    private let didCreateQuerySubscription = UserDefaults.standard.bool(forKey: "didCreateQuerySubscription")
+    // ローカル通知を扱うクラスのインスタンス
+    private let notificationManager = NotificationManager()
+    // MARK: - メソッド
     // 起動時
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
+    func application(_ application: UIApplication,
+                     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
         print("アプリ起動")
         // ローカル通知の許可
-        NotificationManager().requestPermission()
-        // データベース
-        let containerIdentifier = "iCloud.InventoryApp-okubo"
-        let ckContainer = CKContainer(identifier: containerIdentifier)
-        let cloudDatabase = ckContainer.privateCloudDatabase
-        // cloud変更のサブスクリプション作成
-        let subscriptionID = "com.apple.coredata.cloudkit.private.subscription"
-        let ckSubscription = CKQuerySubscription(recordType: "CD_Item",
-                                               predicate: NSPredicate(value: true),
-                                               subscriptionID: subscriptionID,
-                                               options: [.firesOnRecordCreation,
-                                                         .firesOnRecordUpdate,
-                                                         .firesOnRecordDeletion])
-        let recordZoneName = "com.apple.coredata.cloudkit.zone"
-        let recordZone = CKRecordZone(zoneName: recordZoneName)
-        ckSubscription.zoneID = recordZone.zoneID
-        // 通知設定
-        let notification = CKSubscription.NotificationInfo()
-        notification.shouldSendContentAvailable = true
-        // 通知されるデータを設定
-        notification.desiredKeys = ["CD_name", "CD_id", "CD_notificationDate"]
-        ckSubscription.notificationInfo = notification
-        // TODO: - 一度iCloudの同期を切って戻してもサブスクリプションがエラーになり続けて機能しなくなる不具合
-        // データベースにサブスクリプションを登録
-        cloudDatabase.save(ckSubscription) { subscription, error in
-            if let error = error {
-                print("サブスクリプション失敗： \(error.localizedDescription)")
-            } else {
-                print("サブスクリプション開始： \(String(describing: subscription))")
+        notificationManager.requestPermission()
+        print("ユーザーデフォルト: \(didCreateQuerySubscription)")
+        // ユーザーデフォルトの値がfalseの時の処理（サブスクリプション作成）
+        if !didCreateQuerySubscription {
+            // データベース
+            let containerIdentifier = "iCloud.InventoryApp-okubo"
+            let ckContainer = CKContainer(identifier: containerIdentifier)
+            let cloudDatabase = ckContainer.privateCloudDatabase
+            // cloud変更のサブスクリプション作成
+            let subscriptionID = "com.apple.coredata.cloudkit.private.subscription"
+            let ckSubscription = CKQuerySubscription(recordType: "CD_Item",
+                                                     predicate: NSPredicate(value: true),
+                                                     subscriptionID: subscriptionID,
+                                                     options: [.firesOnRecordCreation,
+                                                               .firesOnRecordUpdate,
+                                                               .firesOnRecordDeletion])
+            let recordZoneName = "com.apple.coredata.cloudkit.zone"
+            let recordZone = CKRecordZone(zoneName: recordZoneName)
+            ckSubscription.zoneID = recordZone.zoneID
+            // 通知設定
+            let notification = CKSubscription.NotificationInfo()
+            notification.shouldSendContentAvailable = true
+            // 通知されるデータを設定
+            notification.desiredKeys = ["CD_name", "CD_id", "CD_notificationDate"]
+            ckSubscription.notificationInfo = notification
+            // iCloudアカウントのチェック
+            CKContainer.default().accountStatus { status, error in
+                if let error = error {
+                    print("iCloudアカウントの状態確認に失敗: \(error.localizedDescription)")
+                }
+                // iCloudアカウントが利用可能な場合にサブスクリプションを作成する
+                if status == .available {
+                    // データベースにサブスクリプションを登録
+                    cloudDatabase.save(ckSubscription) { subscription, error in
+                        if let error = error {
+                            print("サブスクリプション失敗： \(error.localizedDescription)")
+                        } else {
+                            print("サブスクリプション開始： \(String(describing: subscription))")
+                            // ユーザーデフォルト更新
+                            UserDefaults.standard.set(true, forKey: "didCreateQuerySubscription")
+                        }
+                    }
+                }
             }
+        } else {
+            print("サブスクリプション作成済み")
         }
         return true
     }
     // リモート通知を受け取った時の処理
-    func application(_ application: UIApplication, didReceiveRemoteNotification userInfo: [AnyHashable : Any], fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void) {
-        // このユーザーインフォからデータが取れるか調査
+    func application(_ application: UIApplication,
+                     didReceiveRemoteNotification userInfo: [AnyHashable: Any],
+                     fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void) {
+        // ユーザーインフォからデータを取得する
         if let dictionary = userInfo as? [String: NSObject],
            let notification = CKNotification(fromRemoteNotificationDictionary: dictionary),
            let querynotification = notification as? CKQueryNotification {
             // querynotification.queryNotificationReasonが作成・更新・削除を表す
             let reason = querynotification.queryNotificationReason
-            print("変更：\(reason)")
-            print("リモート通知：\(String(describing: querynotification.recordFields))")
+            print("変更：\(reason), リモート通知：\(String(describing: querynotification.recordFields))")
             // 取得したデータ
             guard let recordFields = querynotification.recordFields else { return }
-            // 商品名
-            let name = recordFields["CD_name"] as? String
-            print("商品名：\(String(describing: name))")
-            // 識別ID
-            let id = recordFields["CD_id"] as? String
-            print("id: \(String(describing: id))")
-            // 通知日程
-            if let notificationDate = recordFields["CD_notificationDate"] as? NSNumber {
-                print("通知：\(String(describing: notificationDate)), \(String(describing: type(of: notificationDate)))")
-                let date = Date(timeIntervalSinceReferenceDate: notificationDate.doubleValue)
-                print("日付：\(String(describing: date))")// TimeZoneを指定する必要あり
+            // 識別IDを文字列で取得
+            if let id = recordFields["CD_id"] as? String {
+                print("id: \(String(describing: id))")
+                // クラウドの変更を削除かそれ以外かで分岐
+                if reason == .recordDeleted {
+                    // 通知を削除する
+                    notificationManager.removeNotification(identifier: id)
+                } else {
+                    // 通知日程が設定されているかで分岐
+                    if let notificationDate = recordFields["CD_notificationDate"] as? NSNumber {
+                        print("通知：\(String(describing: notificationDate))")
+                        let date = Date(timeIntervalSinceReferenceDate: notificationDate.doubleValue)
+                        print("日付：\(String(describing: date))")
+                        // 商品名
+                        let name = recordFields["CD_name"] as? String
+                        print("商品名：\(String(describing: name))")
+                        // 通知を更新する
+                        notificationManager.makeNotification(name: name!,
+                                                             notificationDate: date,
+                                                             identifier: id)
+                    } else {
+                        // 通知を削除する
+                        notificationManager.removeNotification(identifier: id)
+                    }
+                }
             }
-            // TODO: - クラウドからの変更を受け取ったとき、通知も更新したい
             completionHandler(.newData)
         } else {
             print("データなし")

--- a/InventoryApp-okubo/InventoryApp-okubo/CoreData/Persistence.swift
+++ b/InventoryApp-okubo/InventoryApp-okubo/CoreData/Persistence.swift
@@ -55,17 +55,25 @@ class PersistenceController {
         description.setOption(true as NSNumber, forKey: NSPersistentHistoryTrackingKey)
         // リモートの変更を検知
         description.setOption(true as NSNumber, forKey: NSPersistentStoreRemoteChangeNotificationPostOptionKey)
+        // iCloud Drive Documents のコードでiCloudが使用可能か検出する。アカウントに変更があるとアプリが再起動される。
+        if FileManager.default.ubiquityIdentityToken == nil {
+            print("iCloud使用不可")
+            // CloudKitとの同期を切る
+            description.cloudKitContainerOptions = nil
+        } else {
+            print("iCloud使用可能")
+//            description.cloudKitContainerOptions = .init(containerIdentifier: "iCloud.InventoryApp-okubo")
+        }
+        // データが重複しないよう外部変更はメモリ内を置き換える
+        container.viewContext.mergePolicy = NSMergePolicy(merge: .mergeByPropertyObjectTrumpMergePolicyType)
+        // クラウドからの変更を自動取得して適用する
+        container.viewContext.automaticallyMergesChangesFromParent = true
+        // 永続ストアをロード
         container.loadPersistentStores(completionHandler: { (_, error) in
             if let error = error as NSError? {
                 fatalError("Unresolved error \(error), \(error.userInfo)")
             }
         })
-        // TODO: - iCloudの同期を切っても、それまで登録していたデータはローカルに残したい
-//        description.cloudKitContainerOptions = nil
-        // データが重複しないよう外部変更はメモリ内を置き換える
-        container.viewContext.mergePolicy = NSMergePolicy(merge: .mergeByPropertyObjectTrumpMergePolicyType)
-        // クラウドからの変更を自動取得して適用する
-        container.viewContext.automaticallyMergesChangesFromParent = true
         do {
             // Contextを現在のPersistentStoreにpinする
             try container.viewContext.setQueryGenerationFrom(.current)
@@ -73,55 +81,4 @@ class PersistenceController {
             print("viewContextを現世代に固定することに失敗しました。")
         }
     }
-    // MARK: - CKQuerySubscriptionがうまくいきそうなので不要に
-    // リモートからの新規トランザクションを監視し、必要に応じて Context の更新などを行う
-    //        NotificationCenter.default.addObserver(self,
-    //                                               selector: #selector(storeRemoteChange(_:)),
-    //                                               name: .NSPersistentStoreRemoteChange,
-    //                                               object: container.persistentStoreCoordinator)
-    // リモートの変更を受け取った時の処理
-//    @objc func storeRemoteChange(_ notification: Notification) {
-//        precondition(notification.name == NSNotification.Name.NSPersistentStoreRemoteChange)
-//        //        print("変更通知：　\(String(describing: notification.userInfo))")
-//        //        let storeURL = notification.userInfo?[NSPersistentStoreURLKey]!
-//        let token = notification.userInfo?[NSPersistentHistoryTokenKey] as? NSPersistentHistoryToken
-//        print("リモート変更通知: \(String(describing: token))")
-//        // データ履歴取得
-//        let historyRequest = NSPersistentHistoryChangeRequest.fetchHistory(after: token)
-//        let result = try? container.newBackgroundContext().execute(historyRequest) as? NSPersistentHistoryResult
-//        //        print("変更履歴：　\(String(describing: result))")
-//        if let transactions = result?.result as? [NSPersistentHistoryTransaction] {
-//            for transaction in transactions {
-//                print("トランザクション：\(String(describing: transaction))")
-//                guard let userInfo = transaction.objectIDNotification().userInfo else { return }
-//                print("ユーザーインフォ：\(userInfo)")
-//                // データ履歴のキー
-//                let insertedKey = "inserted_objectIDs" // 追加
-//                let updatedKey = "updated_objectIDs" // 更新
-//                let deletedKey = "deleted_objectIDs" // 削除
-//                // NSManagedObjectIDの集合に変換
-//                if let updatedID = userInfo[deletedKey] as? Set<NSManagedObjectID> {
-//                    print("ID: \(updatedID)")
-//                    print(type(of: updatedID))
-//                    // NSManagedObjectIDの配列に変換
-//                    let idArray = Array(updatedID)
-//                    // NSPersistentCloudKitContainerからCKRecordsを取得
-//                    let record = container.record(for: idArray[0])
-//                    print("レコード： \(String(describing: record))")
-//                    // CKRecordから値を取りたいキー
-//                    let entityKey = "CD_entityName" // エンティティ名
-//                    let nameKey = "CD_name" // 商品名
-//                    let uuidKey = "CD_id" // UUID
-//                    let notificationKey = "CD_notificationDate" // 通知日程
-//                    let folderKey = "CD_folder" // フォルダ
-//                    if let entity = record?[entityKey] as? String {
-//                        if entity == "Item" {
-//                            let name = record?[nameKey] as? String
-//                            print("レコード： \(String(describing: name))")
-//                        }
-//                    }
-//                }
-//            }
-//        }
-//    }
 }

--- a/InventoryApp-okubo/InventoryApp-okubo/FolderGroup/View/FolderEditView.swift
+++ b/InventoryApp-okubo/InventoryApp-okubo/FolderGroup/View/FolderEditView.swift
@@ -200,8 +200,11 @@ struct FolderEditView: View {
         // フォルダ内の商品データを取得
         let items = folderItems(items: folders[index].items)
         for item in items {
-            // 通知を削除
-            notificationManager.removeNotification(item: item)
+            // ローカル通知の識別ID
+            if let identifier = item.id?.uuidString {
+                // 通知を削除
+                notificationManager.removeNotification(identifier: identifier)
+            }
         }
         // フォルダ削除
         context.delete(folders[index])

--- a/InventoryApp-okubo/InventoryApp-okubo/FolderGroup/View/ItemListView.swift
+++ b/InventoryApp-okubo/InventoryApp-okubo/FolderGroup/View/ItemListView.swift
@@ -98,8 +98,11 @@ struct ItemListView: View {
             // 削除するデータ
             let removeItem = folderItems(items: folder.items)[index]
             print("削除するデータ：\(String(describing: removeItem.name))")
-            // 通知を削除
-            notificationManager.removeNotification(item: removeItem)
+            // ローカル通知の識別ID
+            if let identifier = removeItem.id?.uuidString {
+                // 通知を削除
+                notificationManager.removeNotification(identifier: identifier)
+            }
             // データを削除する
             context.delete(removeItem)
         }

--- a/InventoryApp-okubo/InventoryApp-okubo/ItemDataGroup/View/ItemDataView.swift
+++ b/InventoryApp-okubo/InventoryApp-okubo/ItemDataGroup/View/ItemDataView.swift
@@ -330,13 +330,18 @@ struct ItemDataView: View {
         item.folder = itemData.folder
         // 登録日も更新
         item.registrationDate = Date()
-        // 通知日に応じて通知を編集
-        if item.notificationDate == nil {
-            // 通知削除
-            notificationManager.removeNotification(item: item)
-        } else {
-            // 通知作成/上書き
-            notificationManager.makeNotification(item: item)
+        // ローカル通知の識別ID
+        if let identifier = item.id?.uuidString {
+            // 通知日に応じて通知を編集
+            if item.notificationDate == nil {
+                // 通知削除
+                notificationManager.removeNotification(identifier: identifier)
+            } else {
+                // 通知作成/上書き
+                notificationManager.makeNotification(name: item.name!,
+                                                     notificationDate: item.notificationDate!,
+                                                     identifier: identifier)
+            }
         }
         // 保存
         do {

--- a/InventoryApp-okubo/InventoryApp-okubo/NotificationManager.swift
+++ b/InventoryApp-okubo/InventoryApp-okubo/NotificationManager.swift
@@ -27,21 +27,23 @@ class NotificationManager: NSObject, UNUserNotificationCenterDelegate {
             }
         }
     }
-    // ローカル通知を作成する関数
-    func makeNotification(item: Item) {
+    /// ローカル通知を作成する関数
+    /// - Parameters:
+    ///   - name: 商品データの商品名
+    ///   - notificationDate: 商品データの通知日時
+    ///   - identifier: 商品データのUUIDの文字列
+    func makeNotification(name: String, notificationDate: Date, identifier: String) {
         // 通知内容
         let content = UNMutableNotificationContent()
         content.title = "期限が近づいています"
-        content.body = "フォルダ：\((item.folder?.name)!)\n商品名：\(item.name!)" // 改行あり
+        content.body = "商品名：\(name)"
         content.sound = .default
         // 日時指定(Itemの通知日時を使用)
-        let notificationDate = item.notificationDate!
+        let notificationDate = notificationDate
         let dateComponent = Calendar.current.dateComponents([.year, .month, .day, .hour, .minute],
                                                             from: notificationDate)
         // トリガー指定
         let trigger = UNCalendarNotificationTrigger(dateMatching: dateComponent, repeats: false)
-        // 通知の識別ID(ItemのUUIDを使用)
-        let identifier = "\(String(describing: item.id))"
         // リクエスト作成
         let request = UNNotificationRequest(identifier: identifier, content: content, trigger: trigger)
         // デリゲート設定
@@ -49,13 +51,18 @@ class NotificationManager: NSObject, UNUserNotificationCenterDelegate {
         // 通知をセット
         UNUserNotificationCenter.current().add(request)
         print("通知作成")
+//        UNUserNotificationCenter.current().getPendingNotificationRequests { array in
+//            print("セットされた通知: \(array)")
+//        }
     }
-    // 作成された通知を削除する関数
-    func removeNotification(item: Item) {
-        // idをString型に変換
-        let identifier = "\(String(describing: item.id))"
+    /// 作成された通知を削除する関数
+    /// - Parameter identifier: 商品データのUUIDの文字列
+    func removeNotification(identifier: String) {
         // 通知削除
         UNUserNotificationCenter.current().removePendingNotificationRequests(withIdentifiers: [identifier])
         print("通知削除")
+//        UNUserNotificationCenter.current().getPendingNotificationRequests { array in
+//            print("セットされた通知: \(array)")
+//        }
     }
 }

--- a/InventoryApp-okubo/InventoryApp-okubo/RegisterGroup/RegisterView.swift
+++ b/InventoryApp-okubo/InventoryApp-okubo/RegisterGroup/RegisterView.swift
@@ -191,9 +191,12 @@ struct RegisterView: View {
             item.registrationDate = newItem.registrationDate
             item.folder = newItem.folder
             // 通知日時が設定されている場合
-            if item.notificationDate != nil {
-                // 通知作成
-                notificationManager.makeNotification(item: item)
+            if let date = item.notificationDate,
+               let identifier = item.id?.uuidString {
+                    // 通知作成
+                    notificationManager.makeNotification(name: item.name!,
+                                                         notificationDate: date,
+                                                         identifier: identifier)
             }
         }
         do {


### PR DESCRIPTION
<!-- Issueのテンプレートです。入力できるところを埋めてください。 -->
<!-- 記入しない項目は特になしと記入してください。。 -->

<!-- 関連Isuueを記載してください。close #の後にIssue番号を記載すると連携でき、プルリクのマージ時にIssueもcloseします。 -->
## 関連Isuue番号
close #36

<!-- 追加、または修正する機能の概要を記述してください。 -->
## 追加・変更の概要
クラウドから商品データの変更を受け取ったとき、その商品の期限のローカル通知を作成・更新・削除する。
<!-- なぜこの追加・変更が必要なのか目的を記述してください。 -->
## 変更の目的
商品データの通知日程を設定した時、同期している別のデバイスでも自動でローカル通知を作成できるようにする。
<!-- 進捗状況をチェックボックスで管理してください。 -->
## タスクの進捗状況
- [x] クラウドの変更を取得したときローカル通知を更新する
- [x] iCloudの同期ON/OFFを切り替えた時のエラーを解消する
- [x] サブスクリプションの作成は一度だけにする

<!-- UIのキャプチャ、APIのリクエスト/レスポンス等、変更内容を明確に記述してください。 -->
## 変更内容
ローカル通知関連

- ローカル通知作成・削除を行う関数の引数を変更
- 引数の変更に伴って通知を扱っていた各Viewの処理も修正
- ローカル通知からフォルダ名を削除

iCloudの同期エラー

- PersistenceController初期化の際にiCloud Drive Documentsのコードでアカウントチェックを行うことで、同期の切り替えに対応
<img width="721" alt="スクリーンショット 2022-12-02 15 11 09" src="https://user-images.githubusercontent.com/53589421/205227072-5b90c177-78cd-4156-9340-2d8fe5e946d1.png">

サブスクリプションの作成

- UserDefaultsを使用してサブスクリプションが一度作成されたら、同じ処理を行わないよう変更

<!-- 影響範囲を予め明確に想定して記述してください。 -->
## 影響範囲
AppDelegate, PersistenceController, NotificationManager,  RegisterView, ItemDataView, FolderEditView, ItemListView
<!-- 追加・変更した機能の操作方法を記述してください。キャプチャや動画を添付してください。 -->
## 操作方法
商品データを編集する際、期限の行にあるカレンダーアイコンを押すと期限が有効になり、通知日程を設定できるようになります。
通知日を指定して登録するとローカル通知が作成されます。iCloudに同期している別のデバイスでも同じタイミングでローカル通知が発火すれば成功です。
<!-- テストしたことをリストアップしてください。 -->
## テストしたこと
iCloudの同期を切っている間に別のデバイスで作成したローカル通知が同期を戻した時に作成されるか。
アプリが起動していないときでも、ローカル通知の作成ができているか。
<!-- 相談事項や、重点的にレビューしてほしいところを記述してください。 -->
## 相談事項
